### PR TITLE
tol_induced_tree -> tol_induced_subtree

### DIFF
--- a/tree_of_life.json
+++ b/tree_of_life.json
@@ -63,7 +63,7 @@
         }
     },  
     "test_induced_tree_good": {
-        "test_function": "tol_induced_tree",
+        "test_function": "tol_induced_subtree",
         "test_input": {"ott_ids":[292466, 501678, 267845, 666104, 316878, 102710, 176458]},
         "tests": {
              "of_type": 
@@ -75,7 +75,7 @@
         }
     },  
     "test_induced_tree_null": {
-        "test_function": "tol_induced_tree",
+        "test_function": "tol_induced_subtree",
         "test_input": {},
         "tests": {
             "parameters_error": ["ValueError","Return wrong kind of error, or did return error"]


### PR DESCRIPTION
Finally getting caught to Teams Ruby and Python on the tests, and turned up a disagreement in our function names. The 'induced tree' method is called `tol_induced_tree` in the existing tests and `tol_induced_subtree`[in the API](https://github.com/OpenTreeOfLife/opentree/wiki/Open-Tree-of-Life-APIs#tree_of_life). 

I don't mind changing the R libraries name, but think we've stuck with the API names in most cases?
