### PR TITLE
Changed ID for studies_find_studies test

### DIFF
--- a/studies.json
+++ b/studies.json
@@ -2,7 +2,7 @@
     "test_find_studies": {
         "test_function": "studies_find_studies",
         "test_input": {"property":"ot:studyId",
-                       "value":"pg_719",
+                       "value":"pg_100",
                        "verbose":"True"},
         "tests": {
             "contains": [


### PR DESCRIPTION
Hi all @jeetsukumaran @mjy @jhill1 

As mentioned in OpenTreeOfLife/opentree#651, the example ID used in the `studies/find_sudies` no longer points ot a good record, and so leads to test failures in `rotl` and probably your libraries too.

This change just puts another ID in its place, but wanted to set up a PR rather than just push the change so you could all see if it worked with your libraries.