### PR TITLE
Fix API tests

### DIFF
--- a/studies.json
+++ b/studies.json
@@ -2,7 +2,7 @@
     "test_find_studies": {
         "test_function": "studies_find_studies",
         "test_input": {"property":"ot:studyId",
-                       "value":"pg_100",
+                       "value":"pg_0",
                        "verbose":"True"},
         "tests": {
             "contains": [

--- a/studies.json
+++ b/studies.json
@@ -16,7 +16,7 @@
     "test_find_trees": {
         "test_function": "studies_find_trees",
         "test_input": {"property":"ot:ottTaxonName",
-                       "value":"Garcinia"
+                       "value":"Anas"
                       },
         "tests": {
             "contains": [

--- a/studies.json
+++ b/studies.json
@@ -23,7 +23,7 @@
                 ["matched_studies","Output doesn't contain matched_studies"]
                 ],
             "length_greater_than": [
-                [["matched_studies",1],"Fail - results are actually empty"]
+                [["matched_studies",0],"Fail - results are actually empty"]
                 ]
         }
     },

--- a/tree_of_life.json
+++ b/tree_of_life.json
@@ -70,7 +70,7 @@
                  ["dict","Response is of wrong type"]
                  ,
              "contains": [
-                 ["subtree","Doesn't contain a subtree string"]
+                 ["newick","Doesn't contain a subtree string"]
                  ]
         }
     },


### PR DESCRIPTION
Apparently the API has changed and one of the key has been renamed so I updated the tests.

Additionally, in the original example the study id used didn't actually match any study (as in the example, but it seems that after resolving a bug this ID now matches a study). I updated the test so it will return an "empty" study.

There must be another bug in their API as the tree search that used to return results with the genus `Garcinia` doesn't work anymore.

The tests now pass, but I'll ping the OTL team to mention these issues.